### PR TITLE
Fix dataset split ratio attribute

### DIFF
--- a/dataset/ConText.py
+++ b/dataset/ConText.py
@@ -20,14 +20,19 @@ class MakeList(object):
         for c_id, c in enumerate(self.category):
             print(c_id, '\t', c)
 
-        self.ration = ratio
+        # train/validation split ratio
+        self.ratio = ratio
 
     def get_data(self):
         all_data = []
         for img in self.all_image:
             label = self.deal_label(img)
             all_data.append([os.path.join(self.image_root, img), label])
-        train, val = train_test_split(all_data, random_state=1, train_size=self.ration)
+        train, val = train_test_split(
+            all_data,
+            random_state=1,
+            train_size=self.ratio,
+        )
         return train, val
 
     def deal_label(self, img_name):


### PR DESCRIPTION
## Summary
- fix a typo in `dataset/ConText.py` by renaming `ration` to `ratio`
- format the train/validation split code for clarity

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6856465062cc8321a3bc0120d26f910c